### PR TITLE
feat: ユーザー編集時のフラッシュメッセージ表示

### DIFF
--- a/app/controllers/proposal/users_controller.rb
+++ b/app/controllers/proposal/users_controller.rb
@@ -13,9 +13,10 @@ class Proposal::UsersController < Proposal::ApplicationController
     @user.role = :proposal
 
     if @user.update(user_params)
-      redirect_to proposal_root_path, notice: "ユーザー情報を更新しました"
+      redirect_to proposal_root_path, flash: { success: "ユーザー情報を更新しました" }
     else
-      render :edit
+      flash.now[:error] = "ユーザー情報の更新に失敗しました"
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  def flash_background_color(name)
+    case name.to_sym
+    when :success
+      'bg-green-100'
+    when :error, :alert
+      'bg-red-100'
+    when :warning
+      'bg-yellow-100'
+    when :notice, :info
+      'bg-blue-100'
+    end
+  end
+
+  def flash_text_color(name)
+    case name.to_sym
+    when :success
+      'text-green-700'
+    when :error, :alert
+      'text-red-700'
+    when :warning
+      'text-yellow-700'
+    when :notice, :info
+      'text-blue-700'
+    end
+  end
+
+  def flash_icon(name)
+    case name.to_sym
+    when :success
+      '<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+      </svg>'.html_safe
+    when :error, :alert
+      '<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+      </svg>'.html_safe
+    when :warning
+      '<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+      </svg>'.html_safe
+    when :notice, :info
+      '<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+      </svg>'.html_safe
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,10 @@
       <%= render "shared/header" %>
     </header>
 
+    <div class="my-1">
+      <%= render "shared/flash_message" %>
+    </div>
+
     <main class="container mx-auto py-15 grow">
       <%= yield %>
     </main>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,13 @@
+<% flash.each do |name, message| %>
+  <div class="mb-4 rounded-2xl p-4 <%= flash_background_color(name) %> <%= flash_text_color(name) %> flex items-center justify-between">
+    <div class="flex items-center">
+      <%= flash_icon(name) %>
+      <p class="ml-3 text-base font-medium"><%= message %></p>
+    </div>
+    <button type="button" class="opacity-70 hover:opacity-100 ml-4" onclick="this.parentElement.remove()">
+      <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+      </svg>
+    </button>
+  </div>
+<% end %>


### PR DESCRIPTION
# issue
close: #9 
※関連するissue番号を書く。例：`close #30`

# 実装概要
ユーザー編集完了 or 失敗時にフラッシュメッセージを表示させる

## 追加実装
`flash` のタイプに応じて表示色を変化させるメソッドをヘルパーメソッドとして実装

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] ユーザー編集完了時に「ユーザー情報を更新しました」というメッセージが表示されること
- [ ] ユーザー編集失敗時に「ユーザー情報の更新に失敗しました」というメッセージが表示されること
- [ ] フラッシュメッセージの種類に応じて文字色や背景色が変化すること

## 補足・備考
ビューは AI に聞きました

## 質問・確認
聞きたいことや確認したいことがあれば