### PR TITLE
fix: ユーザー情報登録を促す before_action を切り出して実装

### DIFF
--- a/app/controllers/proposal/application_controller.rb
+++ b/app/controllers/proposal/application_controller.rb
@@ -1,12 +1,9 @@
 class Proposal::ApplicationController < ApplicationController
-  def require_login
-    unless current_user
-      redirect_to login_path
-      return
-    end
+  before_action :require_user_registration
 
-    if current_user.role == User.roles[:general]
-      redirect_to new_proposal_users_path, alert: "プロポーザルの登録をお願いします"
+  def require_user_registration
+    if current_user.general?
+      redirect_to edit_proposal_users_path, flash: { alert: "ユーザー情報の登録をお願いします" }
     end
   end
 end

--- a/app/controllers/proposal/users_controller.rb
+++ b/app/controllers/proposal/users_controller.rb
@@ -1,5 +1,5 @@
 class Proposal::UsersController < Proposal::ApplicationController
-  skip_before_action :require_user_registration, only: [:edit]
+  skip_before_action :require_user_registration, only: [:edit, :update]
 
   def show
     @user = current_user

--- a/app/controllers/proposal/users_controller.rb
+++ b/app/controllers/proposal/users_controller.rb
@@ -1,4 +1,6 @@
 class Proposal::UsersController < Proposal::ApplicationController
+  skip_before_action :require_user_registration, only: [:edit]
+
   def show
     @user = current_user
     @posts = current_user.posts


### PR DESCRIPTION
# issue
close: #28 
※関連するissue番号を書く。例：`close #30`

# 実装概要
ユーザー情報を登録しなくても `Proposal::ApplicationController` 配下のアクションにアクセスできる問題を修正

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] ユーザー情報が未登録（ロールが `general` ）のユーザーが下記のページにアクセスできないこと
  - [ ] プロポーザル投稿画面
  - [ ] マイページ

## 補足・備考
`general` ロールの判定は Enum のメソッドを使いました
https://api.rubyonrails.org/classes/ActiveRecord/Enum.html

## 質問・確認
もし「`general` ユーザーがプロポーザル投稿画面にアクセスできる」ことが問題でなければ、このプルリクは無視していただいて大丈夫です！