### PR TITLE
feat: 招待枠ページのアクセス制限

### DIFF
--- a/app/controllers/invitations/application_controller.rb
+++ b/app/controllers/invitations/application_controller.rb
@@ -1,12 +1,10 @@
 class Invitations::ApplicationController < ApplicationController
-  def require_login
-    unless current_user
-      redirect_to login_path
-      return
-    end
+  before_action :ensure_invitation_or_admin
 
-    if current_user.role != User.roles[:invitation] || current_user.role != User.roles[:admin]
-      redirect_to new_proposal_users_path, alert: "権限がありません"
+  def ensure_invitation_or_admin
+    # 招待枠ユーザー or 管理者ユーザー以外はアクセス不可
+    if !(current_user.invitation? || current_user.admin?)
+      redirect_to root_path, alert: "権限がありません"
     end
   end
 end

--- a/app/controllers/invitations/posts_controller.rb
+++ b/app/controllers/invitations/posts_controller.rb
@@ -1,4 +1,4 @@
-class Invitations::PostsController < ApplicationController
+class Invitations::PostsController < Invitations::ApplicationController
   def show
     @post = current_user.posts.find_by(id: params[:id])
     if @post.nil?

--- a/app/controllers/invitations/users_controller.rb
+++ b/app/controllers/invitations/users_controller.rb
@@ -1,4 +1,4 @@
-class Invitations::UsersController < ApplicationController
+class Invitations::UsersController < Invitations::ApplicationController
   def show
     @user = current_user
     @posts = current_user.posts


### PR DESCRIPTION
# issue
close: #42 
※関連するissue番号を書く。例：`close #30`

# 実装概要
招待枠ページに対して、招待枠ロールもしくは管理者ロールがないユーザーのアクセスを制限する

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] `admin` or `invitation` ロールのユーザーが下記ページにアクセスできること
  - [ ] 【招待枠】ユーザー詳細ページ
  - [ ] 【招待枠】ユーザー編集ページ
  - [ ] 【招待枠】投稿作成ページ
  - [ ] 【招待枠】投稿詳細ページ
- [ ] `admin` or `invitation` ロール以外のユーザーが下記ページにアクセスした際はトップページにリダイレクトされること
  - [ ] 【招待枠】ユーザー詳細ページ
  - [ ] 【招待枠】ユーザー編集ページ
  - [ ] 【招待枠】投稿作成ページ
  - [ ] 【招待枠】投稿詳細ページ

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば