### PR TITLE
feat: 招待枠ユーザー用のヘッダーを作成

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,6 +9,9 @@
       <% elsif role == User.roles[:proposal] || role == User.roles[:admin] %>
       <li><%= link_to "登壇応募", new_proposal_post_path %></li>
       <li><%= link_to "マイページ", proposal_root_path %></li>
+      <% elsif role == User.roles[:invitation] %>
+      <li><%= link_to "登壇応募", new_invitations_post_path %></li>
+      <li><%= link_to "マイページ", invitations_root_path %></li>
       <% end %>
 
       <% if role == User.roles[:admin] %>


### PR DESCRIPTION
# issue
close: #27 
※関連するissue番号を書く。例：`close #30`

# 実装概要
実装した内容をここに書く

招待枠ユーザーがログインしているときのヘッダーを作成

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 「登壇応募」を押下すると招待枠用の投稿作成画面に遷移すること
- [ ] 「マイページ」を押下すると招待枠用のユーザー詳細ページに遷移すること

## 補足・備考
なにかあれば

## 質問・確認
管理者ユーザーの「登壇応募」「マイページ」へのリンク先について以下の4つのうち、想定しているものを確認したいです

1. 現状通り、`/proposal` 配下のリンク
2. `/invitations` 配下のリンクに変更
3. `/admin` 配下にルーティングを新しく作成し、適応
4. その他