### PR TITLE
feat:管理者画面の応募一覧を実装

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,5 @@
+class Admin::PostsController < Admin::ApplicationController
+  def index
+    @posts = Post.all
+  end
+end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PostsController < Admin::ApplicationController
   def index
-    @posts = Post.all
+    @posts = Post.includes(:user).all
   end
 end

--- a/app/views/admin/posts/_post.html.erb
+++ b/app/views/admin/posts/_post.html.erb
@@ -1,0 +1,8 @@
+<li class="bg-orange-50 rounded-lg p-4 shadow-md hover:shadow-lg transition border border-orange-300">
+  <h3 class="text-lg font-semibold text-orange-700 mb-2"><%= post.title %></h3>
+  <h4 class="text-sm font-semibold text-orange-700 mb-2">応募者：<%= post.user.name %></h4>
+  <p class="text-gray-600 text-sm line-clamp-3"><%= post.content %></p>
+  <div class="mt-3 text-right">
+    <%= link_to '詳細を見る', "#", class: "text-orange-500 font-semibold hover:underline" %>
+  </div>
+</li>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,15 @@
+<div class="max-w-4xl mx-auto p-6">
+  <h1 class="text-3xl font-bold mb-8 text-center">応募一覧</h1>
+  <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">
+
+    <% if @posts.any? %>
+    <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <% @posts.each do |post| %>
+      <%= render post, post: post %>
+      <% end %>
+    </ul>
+    <% else %>
+    <p class="text-gray-500">応募がありません。</p>
+    <% end %>
+  </article>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -4,9 +4,7 @@
 
     <% if @posts.any? %>
     <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <% @posts.each do |post| %>
-        <%= render post %>
-      <% end %>
+      <%= render @posts %>
     </ul>
     <% else %>
     <p class="text-gray-500">応募がありません。</p>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -5,7 +5,7 @@
     <% if @posts.any? %>
     <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <% @posts.each do |post| %>
-      <%= render post, post: post %>
+        <%= render post %>
       <% end %>
     </ul>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: "users#index"
+    resources :posts, only: %i[index]
   end
 end


### PR DESCRIPTION
# issue
close: #11
※関連するissue番号を書く。例：`close #30`

# 実装概要
管理者画面の応募一覧を実装しました。

<img width="1448" alt="応募一覧画面" src="https://github.com/user-attachments/assets/b77b0cef-40a4-4651-8fc4-11bb0e430775" />


## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] /admin/postsにアクセスすると応募一覧が見られる
- [ ] 応募一覧にはタイトル、内容、応募者の名前が表示されている

## 補足・備考
どこからもリンクは繋がっていないので直でURL打ってください（遷移はissue10）
「詳細を見る」ボタンも存在だけありますがどこにも繋がっていません（応募詳細はissue12）

## 質問・確認
聞きたいことや確認したいことがあれば