### PR TITLE
fix: プロポーザル詳細画面で応募が見つからなかった場合の遷移先を修正

### DIFF
--- a/app/controllers/proposal/posts_controller.rb
+++ b/app/controllers/proposal/posts_controller.rb
@@ -2,7 +2,7 @@ class Proposal::PostsController < Proposal::ApplicationController
   def show
     @post = current_user.posts.find_by(id: params[:id])
     if @post.nil?
-      redirect_to proposal_posts_path, alert: 'プロポーザルが見つかりません。'
+      redirect_to proposal_root_path, alert: 'プロポーザルが見つかりません。'
     end
   end
 


### PR DESCRIPTION
# issue
close: #51 
※関連するissue番号を書く。例：`close #30`

# 実装概要
閲覧権限のない応募詳細画面に遷移すると404Not Foundになるので、マイページに飛ばす

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] URL直叩きで閲覧権限のない応募詳細画面を開こうとすると、マイページに遷移すること `/proposal/posts/:id`
- [ ] マイページに遷移したあと「プロポーザルが見つかりません。」とflash表示されること

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば