### PR TITLE
feat: 管理者ユーザーログイン時の遷移先を設定

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,9 +1,6 @@
 class Admin::ApplicationController < ApplicationController
   def require_login
-    unless current_user
-      redirect_to login_path
-      return
-    end
+    redirect_to login_path and return unless current_user
 
     unless current_user.admin?
       redirect_to root_path, alert: "権限がありません"

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,8 +1,11 @@
 class Admin::ApplicationController < ApplicationController
   def require_login
-    redirect_to login_path unless current_user
+    unless current_user
+      redirect_to login_path
+      return
+    end
 
-    if !current_user.admin?
+    unless current_user.admin?
       redirect_to root_path, alert: "権限がありません"
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -43,6 +43,8 @@ class SessionsController < ApplicationController
   private
 
   def redirect_path_for_user(user, is_existing_user)
+    # 管理者ユーザー
+    return admin_root_path if user.admin?
     # データベースに存在する招待枠ユーザー
     return invitations_root_path if user.invitation? && is_existing_user
     # データベースに存在しない招待枠ユーザー


### PR DESCRIPTION
# issue
close: #57 
※関連するissue番号を書く。例：`close #30`

# 実装概要
管理者ユーザーがログインした際に管理画面のユーザー一覧ページに遷移するように設定

## 追加実装
ログアウト状態で `/admin` にアクセスした際にエラーが発生したので修正
[![Image from Gyazo](https://i.gyazo.com/f0ce2cda4b23cfd5b0ff07247250a8c9.png)](https://gyazo.com/f0ce2cda4b23cfd5b0ff07247250a8c9)

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] ロールが `admin` のユーザーがログインした時、管理画面のユーザー一覧ページに遷移すること
- [ ] ログアウト状態で `/admin` にアクセスした時、 ログインページに遷移すること

## 補足・備考
#### ログアウト時の `NoMethodError` の対応について

初めは `current_user&.admin?` に修正したんですが、複数の `render` or `redirect` が呼ばれたって怒られました
[![Image from Gyazo](https://i.gyazo.com/fe754c676c2160538a329e774215c157.png)](https://gyazo.com/fe754c676c2160538a329e774215c157)

`redirect_to` が同じメソッド内で2つあるのが原因みたいなのでログインページに飛ばす処理を~~早期リターン~~ `and return` 使う形にしました

## 質問・確認
聞きたいことや確認したいことがあれば