### PR TITLE
fix: 応募一覧へのリンクが消えていたので戻す

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,7 @@
         <% elsif current_user.admin? %>
           <li><%= link_to "登壇応募（プロポーザル）", new_proposal_post_path %></li>
           <li><%= link_to "登壇応募（招待枠）", new_invitations_post_path %></li>
+          <li><%= link_to "応募一覧", admin_posts_path %></li>
           <li><%= link_to "管理者画面", admin_root_path %></li>
         <% end %>
       <% end %>


### PR DESCRIPTION
# issue
close: #[issue番号]
※関連するissue番号を書く。例：`close #30`

# 実装概要
#50 で実装されていた「応募一覧」へのリンクの反映ができていなかったので修正

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 管理者ユーザーでログイン時、ヘッダーに応募一覧へのリンクが存在すること
- [ ] 
- [ ] 

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば