### PR TITLE
fix: 管理者ヘッダーにおける招待枠の文言修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,7 @@
           <li><%= link_to "マイページ", invitations_root_path %></li>
         <% elsif current_user.admin? %>
           <li><%= link_to "登壇応募（プロポーザル）", new_proposal_post_path %></li>
-          <li><%= link_to "登壇応募（招待枠）", new_invitations_post_path %></li>
+          <li><%= link_to "登壇内容登録（招待枠）", new_invitations_post_path %></li>
           <li><%= link_to "応募一覧", admin_posts_path %></li>
           <li><%= link_to "管理者画面", admin_root_path %></li>
         <% end %>


### PR DESCRIPTION
# issue
close: #65 
※関連するissue番号を書く。例：`close #30`

# 実装概要
管理者用ヘッダーにおける招待枠用の登録画面へのリンクの文言を修正

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 
- [ ] 
- [ ] 

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば