### PR TITLE
feat: 管理者用の応募一覧画面に応募枠とターゲットを追加

### DIFF
--- a/app/views/admin/posts/_post.html.erb
+++ b/app/views/admin/posts/_post.html.erb
@@ -1,6 +1,8 @@
 <li class="bg-orange-50 rounded-lg p-4 shadow-md hover:shadow-lg transition border border-orange-300">
   <h3 class="text-lg font-semibold text-orange-700 mb-2"><%= post.title %></h3>
   <h4 class="text-sm font-semibold text-orange-700 mb-2">応募者：<%= post.user.name %></h4>
+  <h4 class="text-sm font-semibold text-orange-700 mb-2">応募枠：<%= post.presentation_category %></h4>
+  <h4 class="text-sm font-semibold text-orange-700 mb-2">ターゲット：<%= post.target_category %></h4>
   <p class="text-gray-600 text-sm line-clamp-3"><%= post.content %></p>
   <div class="mt-3 text-right">
     <%= link_to '詳細を見る', admin_post_path(post), class: "text-orange-500 font-semibold hover:underline" %>


### PR DESCRIPTION
# issue
close: #52
※関連するissue番号を書く。例：`close #30`

# 実装概要
管理者用の応募一覧画面で応募枠とターゲットも閲覧できるようにしました。
URL：`admin/posts`
![応募一覧画面](https://i.gyazo.com/1564aa6489c086a8be64a6dadc1c6e9e.png)

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 管理者用の応募一覧画面で各応募に応募枠とターゲットが表示されている。

## 補足・備考
管理者用画面のためi18nを使用せず、enumのkeyをそのまま表示しました。
i18nを使用した場合は下記のようになります。
![応募一覧画面_i18n](https://i.gyazo.com/c29ed68e81687422520b53b07ecd195a.png)

## 質問・確認
聞きたいことや確認したいことがあれば