### PR TITLE
fix: 応募の表示崩れの修正

### DIFF
--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,32 +1,5 @@
 <article class="max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-2xl border border-gray-200">
-  <h1 class="text-3xl font-bold text-gray-800 mb-4">応募内容</h1>
-
-  <div class="bg-gray-100 p-4 rounded-lg mb-6">
-    <h2 class="text-2xl font-semibold text-blue-600"><%= @post.title %></h2>
-  </div>
-
-  <section class="space-y-4">
-    <div class="bg-blue-50 p-4 rounded-lg border-l-4 border-blue-500">
-      <h3 class="text-lg font-semibold text-blue-700">応募枠</h3>
-      <p class="text-gray-700"><%= @post.presentation_category_i18n %></p>
-    </div>
-
-    <div class="bg-green-50 p-4 rounded-lg border-l-4 border-green-500">
-      <h3 class="text-lg font-semibold text-green-700">ターゲット</h3>
-      <p class="text-gray-700"><%= @post.target_category_i18n %></p>
-    </div>
-
-    <div class="bg-pink-50 p-4 rounded-lg border-l-4 border-pink-500">
-      <h3 class="text-lg font-semibold text-pink-700">内容</h3>
-      <p class="text-gray-700 whitespace-pre-wrap"><%= @post.content %></p>
-    </div>
-
-    <div class="bg-pink-50 p-4 rounded-lg border-l-4 border-gray-500">
-      <h3 class="text-lg font-semibold text-gray-700">応募者</h3>
-      <p class="text-gray-700 whitespace-pre-wrap"><%= @post.user.name %></p>
-    </div>
-  </section>
-
+  <%= render "shared/post_show" %>
   <!-- Todo:採択・不採択ボタンを追加 -->
   <!-- Todo:候補・取り消しボタンを追加 -->
   <%= link_to "戻る" , admin_posts_path, class: "block mt-6 text-center text-blue-600 underline" %>

--- a/app/views/invitations/posts/show.html.erb
+++ b/app/views/invitations/posts/show.html.erb
@@ -1,26 +1,4 @@
 <article class="max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-2xl border border-gray-200">
-  <h1 class="text-3xl font-bold text-gray-800 mb-4">応募内容</h1>
-
-  <div class="bg-gray-100 p-4 rounded-lg mb-6">
-    <h2 class="text-2xl font-semibold text-blue-600"><%= @post.title %></h2>
-  </div>
-
-  <section class="space-y-4">
-    <div class="bg-blue-50 p-4 rounded-lg border-l-4 border-blue-500">
-      <h3 class="text-lg font-semibold text-blue-700">応募枠</h3>
-      <p class="text-gray-700"><%= @post.presentation_category_i18n %></p>
-    </div>
-
-    <div class="bg-green-50 p-4 rounded-lg border-l-4 border-green-500">
-      <h3 class="text-lg font-semibold text-green-700">ターゲット</h3>
-      <p class="text-gray-700"><%= @post.target_category_i18n %></p>
-    </div>
-
-    <div class="bg-pink-50 p-4 rounded-lg border-l-4 border-pink-500">
-      <h3 class="text-lg font-semibold text-pink-700">内容</h3>
-      <p class="text-gray-700"><%= @post.content %></p>
-    </div>
-  </section>
-
+  <%= render "shared/post_show" %>
   <%= link_to "戻る" , invitations_root_path, class: "block mt-6 text-center text-blue-600 underline" %>
 </article>

--- a/app/views/proposal/posts/new.html.erb
+++ b/app/views/proposal/posts/new.html.erb
@@ -120,7 +120,7 @@
         <p>登壇カテゴリ: <span id="presentation_category"></span></p>
         <p>参加者ターゲット: <span id="target_category"></span></p>
         <p>内容</p>
-        <p id="content" class="whitespace-pre-wrap"></p>
+        <p id="content" class="whitespace-pre-wrap break-words"></p>
         <div class="flex flex-col justify-center items-center mt-4 gap-5 md:flex-row">
           <%= button_tag "戻る", type: "button", id: "back", class: "uk-button uk-button-secondary" %>
           <%= form.submit "これで投稿する", class: "uk-button uk-button-primary" %>

--- a/app/views/proposal/posts/show.html.erb
+++ b/app/views/proposal/posts/show.html.erb
@@ -1,26 +1,4 @@
 <article class="max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-2xl border border-gray-200">
-  <h1 class="text-3xl font-bold text-gray-800 mb-4">応募内容</h1>
-
-  <div class="bg-gray-100 p-4 rounded-lg mb-6">
-    <h2 class="text-2xl font-semibold text-blue-600"><%= @post.title %></h2>
-  </div>
-
-  <section class="space-y-4">
-    <div class="bg-blue-50 p-4 rounded-lg border-l-4 border-blue-500">
-      <h3 class="text-lg font-semibold text-blue-700">応募枠</h3>
-      <p class="text-gray-700"><%= @post.presentation_category_i18n %></p>
-    </div>
-
-    <div class="bg-green-50 p-4 rounded-lg border-l-4 border-green-500">
-      <h3 class="text-lg font-semibold text-green-700">ターゲット</h3>
-      <p class="text-gray-700"><%= @post.target_category_i18n %></p>
-    </div>
-
-    <div class="bg-pink-50 p-4 rounded-lg border-l-4 border-pink-500">
-      <h3 class="text-lg font-semibold text-pink-700">内容</h3>
-      <p class="text-gray-700 whitespace-pre-wrap"><%= @post.content %></p>
-    </div>
-  </section>
-
+  <%= render "shared/post_show" %>
   <%= link_to "戻る" , proposal_root_path, class: "block mt-6 text-center text-blue-600 underline" %>
 </article>

--- a/app/views/shared/_post_show.html.erb
+++ b/app/views/shared/_post_show.html.erb
@@ -1,0 +1,22 @@
+<h1 class="text-3xl font-bold text-gray-800 mb-4">応募内容</h1>
+
+<div class="bg-gray-100 p-4 rounded-lg mb-6">
+  <h2 class="text-2xl font-semibold text-blue-600"><%= @post.title %></h2>
+</div>
+
+<section class="space-y-4">
+  <div class="bg-blue-50 p-4 rounded-lg border-l-4 border-blue-500">
+    <h3 class="text-lg font-semibold text-blue-700">応募枠</h3>
+    <p class="text-gray-700"><%= @post.presentation_category_i18n %></p>
+  </div>
+
+  <div class="bg-green-50 p-4 rounded-lg border-l-4 border-green-500">
+    <h3 class="text-lg font-semibold text-green-700">ターゲット</h3>
+    <p class="text-gray-700"><%= @post.target_category_i18n %></p>
+  </div>
+
+  <div class="bg-pink-50 p-4 rounded-lg border-l-4 border-pink-500">
+    <h3 class="text-lg font-semibold text-pink-700">内容</h3>
+    <p class="text-gray-700 whitespace-pre-wrap break-words"><%= @post.content %></p>
+  </div>
+</section>


### PR DESCRIPTION
# issue
close: #48 
※関連するissue番号を書く。例：`close #30`

# 実装概要
応募の詳細ページの表示崩れがあったため修正しました。
- 長文が折り返さないのを折り返すように修正
- 内容が同じだったためパーシャル化

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 
- [ ] 
- [ ] 

## 補足・備考
なにかあれば

動作確認は省略

## 質問・確認
聞きたいことや確認したいことがあれば