### PR TITLE
feat: 管理者用の応募一覧に「いいね数順」でソートできる機能を追加

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,7 +1,11 @@
 class Admin::PostsController < Admin::ApplicationController
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result.includes(:user).order(created_at: :desc)
+    @posts = if params[:sort_by] == 'favorite'
+                @q.result.includes(:candidates, :user).sort { |a,b| b.candidates.count <=> a.candidates.count }
+              else
+                @q.result.includes(:user).order(created_at: :desc)
+              end
   end
 
   def show

--- a/app/views/admin/posts/_search.html.erb
+++ b/app/views/admin/posts/_search.html.erb
@@ -38,4 +38,7 @@
       </div>
     </div>
   <% end %>
+  <%= link_to 'いいね数順', admin_posts_path(request.query_parameters.merge(sort_by: 'favorite')), class: "text-orange-500 font-semibold hover:underline ml-3" %>
+  /
+  <%= link_to '新しい順', admin_posts_path(request.query_parameters.merge(sort_by: '')), class: "text-orange-500 font-semibold hover:underline" %>
 </div>


### PR DESCRIPTION
# issue
close: #18  
※関連するissue番号を書く。例：`close #30`

# 実装概要
管理者用の応募一覧画面にいいね数順でソートできるリンクを追加しました。
いいね数順↓
![いいね数順](https://i.gyazo.com/c089ad4bb69d1836a89a558529d1368f.png)

## 追加実装
既存の新しい順に戻すリンクも追加しています。
新しい順↓
![新しい順](https://i.gyazo.com/a93f6b1c17af73a65cb86c404ed80479.png)

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 「いいね数順」のリンクを押下した時、応募がいいねの多い順で表示されること
- [ ] 「新しい順」のリンクを押下した時、応募が新しい順で表示されること
- [ ] 「いいね数順」のリンクを押下した時、検索内容が保持されていること
- [ ] 「新しい順」のリンクを押下した時、検索内容が保持されていること

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば