### PR TITLE
feat: 一言コメント機能を追加

### DIFF
--- a/app/controllers/admin/mypages_controller.rb
+++ b/app/controllers/admin/mypages_controller.rb
@@ -18,6 +18,6 @@ class Admin::MypagesController < Admin::ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url)
+    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url, :comment)
   end
 end

--- a/app/controllers/invitations/users_controller.rb
+++ b/app/controllers/invitations/users_controller.rb
@@ -21,6 +21,6 @@ class Invitations::UsersController < Invitations::ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url)
+    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url, :comment)
   end
 end

--- a/app/controllers/proposal/users_controller.rb
+++ b/app/controllers/proposal/users_controller.rb
@@ -26,7 +26,7 @@ class Proposal::UsersController < Proposal::ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url)
+    params.require(:user).permit(:name, :x_id, :social_portfolio_url, :image_url, :comment)
   end
 
   def proposal_time_limit

--- a/app/views/admin/mypages/show.html.erb
+++ b/app/views/admin/mypages/show.html.erb
@@ -24,6 +24,14 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
+        <li>
+          <span class="font-semibold">コメント:</span>
+          <% if current_user.comment.present? %>
+            <%= current_user.comment %>
+          <% else %>
+            <span class="text-gray-500">未設定</span>
+          <% end %>
+        </li>
       </ul>
     </div>
 

--- a/app/views/admin/mypages/show.html.erb
+++ b/app/views/admin/mypages/show.html.erb
@@ -2,42 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-    <div class="flex flex-col md:flex-row items-center md:items-start gap-6">
-      <% if current_user.image_url.present? %>
-      <img src="<%= current_user.image_url %>" alt="ユーザー画像" class="w-28 h-28 rounded-full border-4 border-orange-400 shadow-md">
-      <% else %>
-      <div class="w-28 h-28 rounded-full bg-orange-100 flex items-center justify-center text-orange-500">
-        No Image
-      </div>
-      <% end %>
-
-      <ul class="flex-1 space-y-3 text-gray-700">
-        <li><span class="font-semibold">名前:</span> <%= current_user.name %></li>
-        <li><span class="font-semibold">X ID:</span> <%= current_user.x_id %></li>
-        <li>
-          <span class="font-semibold">ソーシャルポートフォリオ:</span>
-          <% if current_user.social_portfolio_url.present? %>
-          <a href="<%= current_user.social_portfolio_url %>" target="_blank" class="text-orange-500 hover:underline">
-            <%= current_user.social_portfolio_url %>
-          </a>
-          <% else %>
-          <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-        <li class="w-1/2">
-          <span class="font-semibold">コメント:</span>
-          <% if current_user.comment.present? %>
-            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
-          <% else %>
-            <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-      </ul>
-    </div>
-
-    <div class="mt-6 text-right">
-      <%= link_to 'プロフィールを編集', edit_admin_mypages_path, class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
-    </div>
+        <%= render 'shared/user_show' %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/admin/mypages/show.html.erb
+++ b/app/views/admin/mypages/show.html.erb
@@ -24,10 +24,10 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
-        <li>
+        <li class="w-1/2">
           <span class="font-semibold">コメント:</span>
           <% if current_user.comment.present? %>
-            <%= current_user.comment %>
+            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
           <% else %>
             <span class="text-gray-500">未設定</span>
           <% end %>

--- a/app/views/invitations/users/show.html.erb
+++ b/app/views/invitations/users/show.html.erb
@@ -2,42 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-    <div class="flex flex-col md:flex-row items-center md:items-start gap-6">
-      <% if current_user.image_url.present? %>
-      <img src="<%= current_user.image_url %>" alt="ユーザー画像" class="w-28 h-28 rounded-full border-4 border-orange-400 shadow-md">
-      <% else %>
-      <div class="w-28 h-28 rounded-full bg-orange-100 flex items-center justify-center text-orange-500">
-        No Image
-      </div>
-      <% end %>
-
-      <ul class="flex-1 space-y-3 text-gray-700">
-        <li><span class="font-semibold">名前:</span> <%= current_user.name %></li>
-        <li><span class="font-semibold">X ID:</span> <%= current_user.x_id %></li>
-        <li>
-          <span class="font-semibold">ソーシャルポートフォリオ:</span>
-          <% if current_user.social_portfolio_url.present? %>
-          <a href="<%= current_user.social_portfolio_url %>" target="_blank" class="text-orange-500 hover:underline">
-            <%= current_user.social_portfolio_url %>
-          </a>
-          <% else %>
-          <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-        <li class="w-1/2">
-          <span class="font-semibold">コメント:</span>
-          <% if current_user.comment.present? %>
-            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
-          <% else %>
-            <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-      </ul>
-    </div>
-
-    <div class="mt-6 text-right">
-      <%= link_to 'プロフィールを編集', edit_invitations_users_path, class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
-    </div>
+        <%= render 'shared/user_show' %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/invitations/users/show.html.erb
+++ b/app/views/invitations/users/show.html.erb
@@ -24,6 +24,14 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
+        <li>
+          <span class="font-semibold">コメント:</span>
+          <% if current_user.comment.present? %>
+            <%= current_user.comment %>
+          <% else %>
+            <span class="text-gray-500">未設定</span>
+          <% end %>
+        </li>
       </ul>
     </div>
 

--- a/app/views/invitations/users/show.html.erb
+++ b/app/views/invitations/users/show.html.erb
@@ -24,10 +24,10 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
-        <li>
+        <li class="w-1/2">
           <span class="font-semibold">コメント:</span>
           <% if current_user.comment.present? %>
-            <%= current_user.comment %>
+            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
           <% else %>
             <span class="text-gray-500">未設定</span>
           <% end %>

--- a/app/views/proposal/users/show.html.erb
+++ b/app/views/proposal/users/show.html.erb
@@ -2,42 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-    <div class="flex flex-col md:flex-row items-center md:items-start gap-6">
-      <% if current_user.image_url.present? %>
-      <img src="<%= current_user.image_url %>" alt="ユーザー画像" class="w-28 h-28 rounded-full border-4 border-orange-400 shadow-md">
-      <% else %>
-      <div class="w-28 h-28 rounded-full bg-orange-100 flex items-center justify-center text-orange-500">
-        No Image
-      </div>
-      <% end %>
-
-      <ul class="flex-1 space-y-3 text-gray-700">
-        <li><span class="font-semibold">名前:</span> <%= current_user.name %></li>
-        <li><span class="font-semibold">X ID:</span> <%= current_user.x_id %></li>
-        <li>
-          <span class="font-semibold">ソーシャルポートフォリオ:</span>
-          <% if current_user.social_portfolio_url.present? %>
-          <a href="<%= current_user.social_portfolio_url %>" target="_blank" class="text-orange-500 hover:underline">
-            <%= current_user.social_portfolio_url %>
-          </a>
-          <% else %>
-          <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-        <li class="w-1/2">
-          <span class="font-semibold">コメント:</span>
-          <% if current_user.comment.present? %>
-            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
-          <% else %>
-            <span class="text-gray-500">未設定</span>
-          <% end %>
-        </li>
-      </ul>
-    </div>
-
-    <div class="mt-6 text-right">
-      <%= link_to 'プロフィールを編集', edit_proposal_users_path(current_user), class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
-    </div>
+    <%= render 'shared/user_show' %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/proposal/users/show.html.erb
+++ b/app/views/proposal/users/show.html.erb
@@ -24,6 +24,14 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
+        <li>
+          <span class="font-semibold">コメント:</span>
+          <% if current_user.comment.present? %>
+            <%= current_user.comment %>
+          <% else %>
+            <span class="text-gray-500">未設定</span>
+          <% end %>
+        </li>
       </ul>
     </div>
 

--- a/app/views/proposal/users/show.html.erb
+++ b/app/views/proposal/users/show.html.erb
@@ -24,10 +24,10 @@
           <span class="text-gray-500">未設定</span>
           <% end %>
         </li>
-        <li>
+        <li class="w-1/2">
           <span class="font-semibold">コメント:</span>
           <% if current_user.comment.present? %>
-            <%= current_user.comment %>
+            <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
           <% else %>
             <span class="text-gray-500">未設定</span>
           <% end %>

--- a/app/views/shared/_user_form.html.erb
+++ b/app/views/shared/_user_form.html.erb
@@ -30,6 +30,11 @@
     </div>
   </div>
 
+  <div class="flex flex-col">
+    <%= form.label :comment, class: "font-semibold text-gray-700" %>
+    <%= form.text_field :comment, class: "border border-orange-300 rounded-md p-2 focus:ring-orange-500 focus:border-orange-500" %>
+  </div>
+
   <div class="text-center mt-6">
     <%= form.submit "更新", class: "bg-orange-500 text-white px-6 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
   </div>

--- a/app/views/shared/_user_show.html.erb
+++ b/app/views/shared/_user_show.html.erb
@@ -1,0 +1,36 @@
+<div class="flex flex-col md:flex-row items-center md:items-start gap-6">
+  <% if current_user.image_url.present? %>
+    <img src="<%= current_user.image_url %>" alt="ユーザー画像" class="w-28 h-28 rounded-full border-4 border-orange-400 shadow-md">
+  <% else %>
+    <div class="w-28 h-28 rounded-full bg-orange-100 flex items-center justify-center text-orange-500">
+      No Image
+    </div>
+  <% end %>
+
+  <ul class="flex-1 space-y-3 text-gray-700">
+    <li><span class="font-semibold">名前:</span> <%= current_user.name %></li>
+    <li><span class="font-semibold">X ID:</span> <%= current_user.x_id %></li>
+    <li>
+      <span class="font-semibold">ソーシャルポートフォリオ:</span>
+      <% if current_user.social_portfolio_url.present? %>
+        <a href="<%= current_user.social_portfolio_url %>" target="_blank" class="text-orange-500 hover:underline">
+          <%= current_user.social_portfolio_url %>
+        </a>
+      <% else %>
+        span class="text-gray-500">未設定</span>
+      <% end %>
+    </li>
+    <li class="w-1/2">
+      <span class="font-semibold">コメント:</span>
+      <% if current_user.comment.present? %>
+        <p class="whitespace-pre-line break-words"><%= current_user.comment %></p>
+      <% else %>
+        <span class="text-gray-500">未設定</span>
+      <% end %>
+    </li>
+  </ul>
+</div>
+
+<div class="mt-6 text-right">
+  <%= link_to 'プロフィールを編集', edit_proposal_users_path(current_user), class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
+</div>

--- a/db/migrate/20250412105700_add_comment_to_users.rb
+++ b/db/migrate/20250412105700_add_comment_to_users.rb
@@ -1,0 +1,5 @@
+class AddCommentToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :comment, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_29_145809) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_12_105700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_29_145809) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image_url"
+    t.string "comment"
   end
 
   add_foreign_key "candidates", "posts"


### PR DESCRIPTION
# issue
close: #84 
※関連するissue番号を書く。例：`close #30`

# 実装概要
一言コメント機能を追加

## 追加実装
ユーザー詳細画面にコメントを表示
全ユーザーがコメントできるようにする

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

#### 前ロールのユーザー共通で下記の動作をすること
- [ ] ユーザー編集ページにコメント用の入力フォームが表示されていること
[![Image from Gyazo](https://i.gyazo.com/5a8fa7a2982078079aa2ac0b33cb0756.png)](https://gyazo.com/5a8fa7a2982078079aa2ac0b33cb0756)
- [ ] ユーザー詳細ページにコメントが表示されていること
  - [ ] コメントが登録されていない場合は「未設定」と表示されること（ソシャポと同じ挙動）
 [![Image from Gyazo](https://i.gyazo.com/bfa3e98bb86b59a35a31e42c89036ba7.png)](https://gyazo.com/bfa3e98bb86b59a35a31e42c89036ba7)
[![Image from Gyazo](https://i.gyazo.com/10f018fa65d2a86cacad46eb01d8205d.png)](https://gyazo.com/10f018fa65d2a86cacad46eb01d8205d)

## 補足・備考
なにかあれば

## 質問・確認
プレイスホルダーの有無・入れるとすればどんな文言にするか