### PR TITLE
hotfix: ユーザー編集へのリンクが全てプロポーザル用になっていたので修正

### DIFF
--- a/app/views/admin/mypages/show.html.erb
+++ b/app/views/admin/mypages/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-        <%= render 'shared/user_show' %>
+    <%= render 'shared/user_show', edit_profile_path: edit_admin_mypages_path %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/invitations/users/show.html.erb
+++ b/app/views/invitations/users/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-        <%= render 'shared/user_show' %>
+    <%= render 'shared/user_show', edit_profile_path: edit_invitations_users_path %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/proposal/users/show.html.erb
+++ b/app/views/proposal/users/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-3xl font-bold mb-8 text-center">ユーザーページ</h1>
 
   <article class="bg-white shadow-lg rounded-xl p-6 mb-10 border border-orange-200">
-    <%= render 'shared/user_show' %>
+    <%= render 'shared/user_show', edit_profile_path: edit_proposal_users_path(current_user) %>
   </article>
 
   <article class="bg-white shadow-lg rounded-xl p-6 border border-orange-200">

--- a/app/views/shared/_user_show.html.erb
+++ b/app/views/shared/_user_show.html.erb
@@ -32,5 +32,5 @@
 </div>
 
 <div class="mt-6 text-right">
-  <%= link_to 'プロフィールを編集', edit_proposal_users_path(current_user), class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
+  <%= link_to 'プロフィールを編集', edit_profile_path, class: "inline-block bg-orange-500 text-white px-5 py-2 rounded-lg text-lg shadow-md hover:bg-orange-600 transition" %>
 </div>


### PR DESCRIPTION
# issue
close: #[issue番号]
※関連するissue番号を書く。例：`close #30`

# 実装概要
パーシャル化した際にユーザー編集へのリンクが共通でプロポーザルロール用になっていたので、各ロールごとのリンクに修正

## 追加実装
issueに書いていないが追加した実装があればここに理由も合わせて書く

## 動作確認チェックリスト
- issueに書いてある動作確認のチェックリストをここに貼る
- レビュワーが動作確認できたらチェックを入れる

- [ ] 各ロールユーザーがそれぞれのロール用のユーザー編集ページに遷移できること
- [ ] 
- [ ] 

## 補足・備考
なにかあれば

## 質問・確認
聞きたいことや確認したいことがあれば